### PR TITLE
fix: make timezone default to UTC

### DIFF
--- a/src/Http/Resources/Json/FleetbasePaginatedResourceResponse.php
+++ b/src/Http/Resources/Json/FleetbasePaginatedResourceResponse.php
@@ -31,7 +31,10 @@ class FleetbasePaginatedResourceResponse extends PaginatedResourceResponse
     protected function meta($paginated)
     {
         $metaData = parent::meta($paginated);
-
+        $time = 0;
+        if (defined('LARAVEL_START')) {
+            $time = round((microtime(true) - LARAVEL_START) * 1000);
+        }
         return [
             'total'        => $metaData['total'] ?? null,
             'per_page'     => $metaData['per_page'] ?? null,
@@ -39,7 +42,7 @@ class FleetbasePaginatedResourceResponse extends PaginatedResourceResponse
             'last_page'    => $metaData['last_page'] ?? null,
             'from'         => $metaData['from'] ?? null,
             'to'           => $metaData['to'] ?? null,
-            'time'         => round((microtime(true) - LARAVEL_START) * 1000),
+            'time'         => $time,
         ];
     }
 }

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -842,11 +842,11 @@ class User extends Authenticatable
      * This method returns the timezone associated with the user. If no timezone is set,
      * it defaults to 'Asia/Singapore'.
      *
-     * @return string the user's timezone, or 'Asia/Singapore' if not set
+     * @return string the user's timezone, or 'UTC' if not set
      */
     public function getTimezone(): string
     {
-        return data_get($this, 'timezone', 'Asia/Singapore');
+        return data_get($this, 'timezone', 'UTC');
     }
 
     /**

--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -766,7 +766,7 @@ class Utils
      *
      * @return string
      */
-    public static function moneyFormat($amount, $currency = 'USD')
+    public static function moneyFormat($amount, $currency = 'EGP')
     {
         $amount = static::numbersOnly($amount);
         $money  = new \Cknow\Money\Money($amount, $currency);


### PR DESCRIPTION
- Add execution time to the pagination metadata in FleetbasePaginatedResourceResponse.
- Change default currency in money formatting utility from USD to EGP.